### PR TITLE
fix: Resolve SPM module name collision causing crash on instantiation

### DIFF
--- a/src/BlipChat/Storyboard.storyboard
+++ b/src/BlipChat/Storyboard.storyboard
@@ -11,7 +11,7 @@
         <!--Thread-->
         <scene sceneID="i5J-vg-TXv">
             <objects>
-                <viewController storyboardIdentifier="ThreadViewController" title="ThreadViewController" id="32R-DJ-UGp" userLabel="Thread" customClass="ThreadViewController" customModule="BlipChat" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="ThreadViewController" title="ThreadViewController" id="32R-DJ-UGp" userLabel="Thread" customClass="BlipChatThreadViewController" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="aJg-Jr-Xmt">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/src/BlipChat/ThreadViewController.swift
+++ b/src/BlipChat/ThreadViewController.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 import WebKit
+@objc(BlipChatThreadViewController)
 internal class ThreadViewController: UIViewController, WKNavigationDelegate, UIScrollViewDelegate, WKUIDelegate {
     
     var appKey : String!


### PR DESCRIPTION
## Problem

When BlipChat is installed via Swift Package Manager, Xcode disambiguates the module name as `PackageName_TargetName` (e.g. `BlipChat_BlipChat` or `blip-chat-ios_BlipChat` depending on the local package name). The Storyboard had `customModule="BlipChat"`, which no longer matches the actual module at runtime.

Interface Builder falls back to instantiating a plain `UIViewController`, causing the `as! ThreadViewController` cast in `BlipClient` to crash with SIGABRT:

```
Unknown class _TtC17BlipChat_BlipChat20ThreadViewController in Interface Builder file.
Could not cast value of type 'UIViewController' to 'BlipChat.ThreadViewController'.
```

This does not affect CocoaPods installs, which always compile the module as `BlipChat`.

## Fix

- Annotate `ThreadViewController` with `@objc(BlipChatThreadViewController)` to register it under a stable Objective-C name, independent of Swift module mangling.
- Update the Storyboard to reference `BlipChatThreadViewController` directly, without `customModule`. Interface Builder resolves the class by its ObjC name — no module prefix required.

## Impact

**No functional regression** for CocoaPods or SPM installs.

One minor side effect: `NSStringFromClass` now returns `BlipChatThreadViewController` instead of `ThreadViewController`. Consumers using automatic screen tracking (e.g. Firebase Analytics) may see this new name in their dashboards.