### PR TITLE
[Release] 3.4.0

### DIFF
--- a/BlipChat.podspec
+++ b/BlipChat.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "BlipChat"
-  s.version      = "3.3.1"
+  s.version      = "3.4.0"
   s.summary      = "A Swift Framework to easly add BLiP conversations in your iOS app. For more information see BLiP portal and BLiP documentation."
 
   s.homepage     = "https://github.com/takenet/blip-chat-ios"

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "BlipChat",
     platforms: [
-        .iOS(.v18)
+        .iOS(.v15)
     ],
     products: [
         .library(

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To use the BLiP Chat for iOS, you must target iOS 15 or later.
 
         https://github.com/takenet/blip-chat-ios
 
-3.  Select the version rule (e.g. **Up to Next Major** from `3.3.1`) and click **Add Package**.
+3.  Select the version rule (e.g. **Up to Next Major** from `3.4.0`) and click **Add Package**.
 4.  Add `BlipChat` to your app target and start using the SDK.
 
 ### CocoaPods (legacy)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ SDK to easily add BLiP Chat's widget to your iOS app. For more information, see 
 
 ### Prerequisites
 
-To use the BLiP Chat for iOS, you must target iOS 18 or later.
+To use the BLiP Chat for iOS, you must target iOS 15 or later.
 
 ### Swift Package Manager (recommended)
 
@@ -373,7 +373,7 @@ If this occurs, you have two options:
 
 ---
 
-iOS 18+.
+iOS 15+.
 
 ## License
 


### PR DESCRIPTION
This pull request updates the minimum iOS deployment target for the BlipChat SDK from iOS 18 to iOS 15 and bumps the SDK version to 3.4.0. The documentation has been updated to reflect this new minimum requirement.